### PR TITLE
Test showing a recursion error when creating a big tree

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -122,3 +122,12 @@ def test_find_keyerror():
     elt[WILDCARD, 2, 3] = 2
     raises_keyerror(lambda: elt.find((1, 1)), (1, 1))
     raises_keyerror(lambda: elt.find((1, 1, 2, 3), True), (1, 1, 2, 3))
+
+
+def test_building_a_big_tree_should_not_fail_with_maximum_recursion_error():
+    elt = Dictree()
+    for x in range(100):
+        data = range(1000)
+        while data:
+            elt[data] = 0
+            data.pop(0)


### PR DESCRIPTION
We get a `RuntimeError: maximum recursion depth exceeded`
The failure trace is:
```
self = <dictree.dictree.Dictree object at 0x7f2d80d95190>, key = [307, 308, 309, 310, 311, 312, ...], value = 0

    def __setitem__(self, key, value):
        if len(key) == 0:
            self._item = value
    
        else:
            head, tail = key[0], key[1:]
>           self._subtrees.setdefault(head, self.__class__())[tail] = value
E           RuntimeError: maximum recursion depth exceeded

dictree/base.py:45: RuntimeError
```
